### PR TITLE
Add configurable map grid overlay

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -883,3 +883,51 @@ body.resizing .resizer {
 .sticky-note-textarea::placeholder{
   color:rgba(0,0,0,0.4);
 }
+
+/* Map Grid Control */
+.grid-overlay-control{
+  background:rgba(255,255,255,0.95);
+  padding:.6rem .7rem;
+  border-radius:8px;
+  box-shadow:0 4px 12px rgba(0,0,0,0.15);
+  display:flex;
+  flex-direction:column;
+  gap:.5rem;
+  min-width:140px;
+}
+.grid-overlay-title{
+  font-size:.85rem;
+  font-weight:600;
+  color:#333;
+}
+.grid-overlay-size{
+  display:flex;
+  flex-direction:column;
+  gap:.3rem;
+  font-size:.75rem;
+  color:#555;
+}
+.grid-overlay-input{
+  padding:.35rem .4rem;
+  border:1px solid #d0d0d0;
+  border-radius:4px;
+  font-size:.85rem;
+  width:100%;
+}
+.grid-overlay-toggle{
+  border:none;
+  background:#9D2235;
+  color:#fff;
+  padding:.45rem;
+  border-radius:4px;
+  font-size:.85rem;
+  font-weight:600;
+  cursor:pointer;
+  transition:background .2s ease;
+}
+.grid-overlay-toggle:hover{
+  background:#C5283D;
+}
+.grid-overlay-toggle.active{
+  background:#444;
+}

--- a/assets/js/grid-overlay.js
+++ b/assets/js/grid-overlay.js
@@ -1,0 +1,152 @@
+(function() {
+  if (typeof map === 'undefined') {
+    console.error('Grid overlay requires the global map instance.');
+    return;
+  }
+
+  const GRID_MIN_KM = 0.1;
+  const DEFAULT_GRID_KM = 1;
+  let gridEnabled = false;
+  let gridSizeKm = DEFAULT_GRID_KM;
+  const gridLayer = L.layerGroup();
+
+  function clampGridSize(value) {
+    if (Number.isNaN(value) || !Number.isFinite(value)) {
+      return gridSizeKm;
+    }
+    return Math.max(GRID_MIN_KM, value);
+  }
+
+  function formatInputValue(value) {
+    return Number.parseFloat(value.toFixed(2));
+  }
+
+  function updateGrid() {
+    if (!gridEnabled) {
+      return;
+    }
+
+    const cellSizeMeters = gridSizeKm * 1000;
+    if (cellSizeMeters <= 0) {
+      return;
+    }
+
+    const bounds = map.getBounds().pad(0.5);
+    const crs = map.options.crs || L.CRS.EPSG3857;
+    const southWest = crs.project(bounds.getSouthWest());
+    const northEast = crs.project(bounds.getNorthEast());
+
+    const minX = Math.min(southWest.x, northEast.x);
+    const maxX = Math.max(southWest.x, northEast.x);
+    const minY = Math.min(southWest.y, northEast.y);
+    const maxY = Math.max(southWest.y, northEast.y);
+
+    const startX = Math.floor(minX / cellSizeMeters) * cellSizeMeters;
+    const endX = Math.ceil(maxX / cellSizeMeters) * cellSizeMeters;
+    const startY = Math.floor(minY / cellSizeMeters) * cellSizeMeters;
+    const endY = Math.ceil(maxY / cellSizeMeters) * cellSizeMeters;
+
+    gridLayer.clearLayers();
+
+    for (let x = startX; x <= endX; x += cellSizeMeters) {
+      const startPoint = L.point(x, minY);
+      const endPoint = L.point(x, maxY);
+      const startLatLng = crs.unproject(startPoint);
+      const endLatLng = crs.unproject(endPoint);
+      const line = L.polyline([startLatLng, endLatLng], {
+        color: '#333',
+        opacity: 0.35,
+        weight: 1,
+        interactive: false
+      });
+      gridLayer.addLayer(line);
+    }
+
+    for (let y = startY; y <= endY; y += cellSizeMeters) {
+      const startPoint = L.point(minX, y);
+      const endPoint = L.point(maxX, y);
+      const startLatLng = crs.unproject(startPoint);
+      const endLatLng = crs.unproject(endPoint);
+      const line = L.polyline([startLatLng, endLatLng], {
+        color: '#333',
+        opacity: 0.35,
+        weight: 1,
+        interactive: false
+      });
+      gridLayer.addLayer(line);
+    }
+  }
+
+  function enableGrid() {
+    if (!gridEnabled) {
+      gridEnabled = true;
+      gridLayer.addTo(map);
+      updateGrid();
+    }
+  }
+
+  function disableGrid() {
+    if (gridEnabled) {
+      gridEnabled = false;
+      gridLayer.clearLayers();
+      map.removeLayer(gridLayer);
+    }
+  }
+
+  function toggleGrid(button) {
+    if (gridEnabled) {
+      disableGrid();
+      button.classList.remove('active');
+      button.innerText = 'Show Grid';
+    } else {
+      enableGrid();
+      button.classList.add('active');
+      button.innerText = 'Hide Grid';
+    }
+  }
+
+  const GridOverlayControl = L.Control.extend({
+    options: { position: 'topright' },
+    onAdd() {
+      const container = L.DomUtil.create('div', 'leaflet-control grid-overlay-control');
+
+      const title = L.DomUtil.create('div', 'grid-overlay-title', container);
+      title.textContent = 'Map Grid';
+
+      const sizeWrapper = L.DomUtil.create('label', 'grid-overlay-size', container);
+      sizeWrapper.textContent = 'Cell size (km)';
+
+      const sizeInput = L.DomUtil.create('input', 'grid-overlay-input', sizeWrapper);
+      sizeInput.type = 'number';
+      sizeInput.min = GRID_MIN_KM;
+      sizeInput.step = '0.1';
+      sizeInput.value = formatInputValue(gridSizeKm);
+
+      const toggleBtn = L.DomUtil.create('button', 'grid-overlay-toggle', container);
+      toggleBtn.type = 'button';
+      toggleBtn.textContent = 'Show Grid';
+
+      L.DomEvent.disableClickPropagation(container);
+      L.DomEvent.disableScrollPropagation(container);
+
+      L.DomEvent.on(toggleBtn, 'click', function() {
+        toggleGrid(toggleBtn);
+      });
+
+      L.DomEvent.on(sizeInput, 'change', function() {
+        const newValue = clampGridSize(parseFloat(sizeInput.value));
+        gridSizeKm = newValue;
+        sizeInput.value = formatInputValue(newValue);
+        if (gridEnabled) {
+          updateGrid();
+        }
+      });
+
+      return container;
+    }
+  });
+
+  map.addControl(new GridOverlayControl());
+
+  map.on('moveend zoomend rotate', updateGrid);
+})();

--- a/geolocator.html
+++ b/geolocator.html
@@ -598,6 +598,7 @@
   </div>
 
   <script src="assets/js/map-setup.js"></script>
+  <script src="assets/js/grid-overlay.js"></script>
   <script src="assets/js/angles-mode.js"></script>
   <script src="assets/js/places-mode.js"></script>
   <script src="assets/js/resizer.js"></script>


### PR DESCRIPTION
## Summary
- add a Leaflet control that can toggle a kilometer-based grid overlay anchored to map coordinates
- provide styling for the control and load the new script in the main application shell

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68e230e0662883279ee71425a7c6f500