### PR TITLE
Track drawings in layer list

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -138,6 +138,9 @@ body.resizing .resizer {
   display:flex;align-items:center;gap:.5rem;
   transition:all 0.2s;cursor:pointer
 }
+.layer-item.drawing-layer{
+  background:#fffdf8;
+}
 .layer-item:hover{
   border-color:#9D2235;background:#f0f4ff
 }
@@ -150,6 +153,12 @@ body.resizing .resizer {
   border-radius:4px;border:1px solid #ddd;
   flex-shrink:0
 }
+.layer-item .drawing-preview{
+  display:flex;align-items:center;justify-content:center;
+  background:#fff;
+  border:1px dashed #c4c4c4;
+  font-size:1rem;
+}
 .layer-item .layer-info{
   flex:1;min-width:0
 }
@@ -157,8 +166,14 @@ body.resizing .resizer {
   font-size:.8rem;font-weight:500;color:#333;
   white-space:nowrap;overflow:hidden;text-overflow:ellipsis
 }
+.layer-item .layer-meta{
+  font-size:.65rem;color:#666;margin-top:.1rem;
+}
 .layer-item .layer-controls{
   display:flex;gap:.3rem;align-items:center;flex-wrap:wrap
+}
+.layer-item.drawing-layer .layer-controls{
+  flex-wrap:nowrap;
 }
 .layer-item input[type=range]{
   width:60px;height:4px;cursor:pointer

--- a/geolocator.html
+++ b/geolocator.html
@@ -403,7 +403,7 @@
         <div class="layers-panel" id="layersPanel">
           <h4>Image Layers</h4>
           <div class="layers-list" id="layersList">
-            <p class="no-layers">No images uploaded</p>
+            <p class="no-layers">No layers yet</p>
           </div>
         </div>
         


### PR DESCRIPTION
## Summary
- register drawings from Konva and Leaflet so they surface in the image layers panel
- wire drawing lifecycle events to keep the list synchronized and allow deleting drawings from the panel
- polish the layer list styling and empty state to accommodate drawing entries

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e23601b80c8327a72e3e9db4784b3a