### PR TITLE
Embed map grid controls in sidebar

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -138,6 +138,9 @@ body.resizing .resizer {
   display:flex;align-items:center;gap:.5rem;
   transition:all 0.2s;cursor:pointer
 }
+.layer-item.drawing-layer{
+  background:#fffdf8;
+}
 .layer-item:hover{
   border-color:#9D2235;background:#f0f4ff
 }
@@ -150,6 +153,12 @@ body.resizing .resizer {
   border-radius:4px;border:1px solid #ddd;
   flex-shrink:0
 }
+.layer-item .drawing-preview{
+  display:flex;align-items:center;justify-content:center;
+  background:#fff;
+  border:1px dashed #c4c4c4;
+  font-size:1rem;
+}
 .layer-item .layer-info{
   flex:1;min-width:0
 }
@@ -157,8 +166,14 @@ body.resizing .resizer {
   font-size:.8rem;font-weight:500;color:#333;
   white-space:nowrap;overflow:hidden;text-overflow:ellipsis
 }
+.layer-item .layer-meta{
+  font-size:.65rem;color:#666;margin-top:.1rem;
+}
 .layer-item .layer-controls{
   display:flex;gap:.3rem;align-items:center;flex-wrap:wrap
+}
+.layer-item.drawing-layer .layer-controls{
+  flex-wrap:nowrap;
 }
 .layer-item input[type=range]{
   width:60px;height:4px;cursor:pointer
@@ -696,6 +711,25 @@ body.resizing .resizer {
   margin-top:1rem;padding-top:1rem;
   border-top:2px solid #f0f0f0
 }
+.layer-toggle__header{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:.5rem;
+  flex-wrap:wrap;
+}
+.layer-toggle__header label{
+  flex:1 1 auto;
+  margin:0;
+}
+.layer-toggle__header .map-grid-control{
+  flex:1 1 170px;
+}
+.layer-toggle__buttons{
+  display:grid;
+  gap:.5rem;
+  margin-top:.6rem
+}
 .toggle-btn{
   width:100%;padding:.6rem;border:2px solid #ddd;
   background:#fff;border-radius:6px;cursor:pointer;
@@ -885,49 +919,50 @@ body.resizing .resizer {
 }
 
 /* Map Grid Control */
-.grid-overlay-control{
-  background:rgba(255,255,255,0.95);
-  padding:.6rem .7rem;
-  border-radius:8px;
-  box-shadow:0 4px 12px rgba(0,0,0,0.15);
+.map-grid-control{
   display:flex;
-  flex-direction:column;
+  align-items:center;
+  justify-content:flex-end;
   gap:.5rem;
-  min-width:140px;
+  flex-wrap:wrap;
 }
-.grid-overlay-title{
-  font-size:.85rem;
+.map-grid-toggle{
+  padding:.35rem .75rem;
+  border:1px solid #ddd;
+  border-radius:6px;
+  background:#fff;
+  font-size:.75rem;
   font-weight:600;
-  color:#333;
+  cursor:pointer;
+  transition:all 0.2s ease;
+  font-family:'Inter',sans-serif;
 }
-.grid-overlay-size{
+.map-grid-toggle:hover{
+  border-color:#9D2235;
+  color:#9D2235;
+}
+.map-grid-toggle.active{
+  background:linear-gradient(135deg,#9D2235,#C5283D);
+  border-color:#9D2235;
+  color:#fff;
+}
+.map-grid-size{
   display:flex;
-  flex-direction:column;
-  gap:.3rem;
+  align-items:center;
+  gap:.4rem;
   font-size:.75rem;
   color:#555;
 }
-.grid-overlay-input{
-  padding:.35rem .4rem;
-  border:1px solid #d0d0d0;
+.map-grid-size input{
+  width:64px;
+  padding:.35rem .45rem;
+  border:1px solid #ccc;
   border-radius:4px;
-  font-size:.85rem;
-  width:100%;
+  font-size:.8rem;
+  font-family:'Inter',sans-serif;
 }
-.grid-overlay-toggle{
-  border:none;
-  background:#9D2235;
-  color:#fff;
-  padding:.45rem;
-  border-radius:4px;
-  font-size:.85rem;
-  font-weight:600;
-  cursor:pointer;
-  transition:background .2s ease;
-}
-.grid-overlay-toggle:hover{
-  background:#C5283D;
-}
-.grid-overlay-toggle.active{
-  background:#444;
+.map-grid-size input:focus{
+  outline:none;
+  border-color:#9D2235;
+  box-shadow:0 0 0 2px rgba(157,34,53,.15);
 }

--- a/geolocator.html
+++ b/geolocator.html
@@ -329,8 +329,17 @@
           <div id="status">Ready</div>
 
           <div class="layer-toggle">
-            <label>Map Layer</label>
-            <div style="display:grid;gap:.5rem">
+            <div class="layer-toggle__header">
+              <label>Map Layer</label>
+              <div class="map-grid-control" id="mapGridControls">
+                <button class="map-grid-toggle" id="mapGridToggle" type="button" aria-pressed="false">Show Grid</button>
+                <label class="map-grid-size" for="mapGridSize">
+                  <span>Cell (km)</span>
+                  <input id="mapGridSize" type="number" min="0.1" step="0.1" value="1" inputmode="decimal"/>
+                </label>
+              </div>
+            </div>
+            <div class="layer-toggle__buttons">
               <button class="toggle-btn active" id="layerStreet" onclick="setMapLayer('street')">
                 🗺️ Street Map
               </button>
@@ -403,7 +412,7 @@
         <div class="layers-panel" id="layersPanel">
           <h4>Image Layers</h4>
           <div class="layers-list" id="layersList">
-            <p class="no-layers">No images uploaded</p>
+            <p class="no-layers">No layers yet</p>
           </div>
         </div>
         


### PR DESCRIPTION
## Summary
- embed a compact map grid toggle and size input alongside the Map Layer heading in the geolocator panel
- restyle the map grid controls to align with the layer header without consuming extra vertical space
- update the grid overlay script to drive the sidebar controls and keep the overlay in sync with map events

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e23601b80c8327a72e3e9db4784b3a