### PR TITLE
Fix drawing when leaving pan mode on image canvas

### DIFF
--- a/assets/js/image-layers.js
+++ b/assets/js/image-layers.js
@@ -879,6 +879,15 @@ function removeLayer(layerId, event) {
   }
 }
 
+function deselectImageLayer() {
+  if (selectedLayerId == null) return;
+  selectedLayerId = null;
+  updateLayersList();
+  redrawAllLayers();
+}
+
+window.deselectImageLayer = deselectImageLayer;
+
 function redrawAllLayers() {
   ctx.setTransform(1, 0, 0, 1, 0, 0);
   ctx.clearRect(0, 0, imageCanvas.width, imageCanvas.height);


### PR DESCRIPTION
## Summary
- ensure Konva overlays restore pointer events after forwarding so drawing works after panning
- automatically clear forwarding and selections when switching away from the pan tool
- deselect image layers when leaving pan mode so drag handles don’t block drawing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e35d5a3ab483279acbdbba6845ef08