### PR TITLE
Fix image canvas annotations respecting zoom and pan

### DIFF
--- a/assets/js/drawing-tools.js
+++ b/assets/js/drawing-tools.js
@@ -59,6 +59,13 @@ class KonvaPanel {
     this.layer = new Konva.Layer();
     this.stage.add(this.layer);
 
+    this.viewportTransform = {
+      scaleX: 1,
+      scaleY: 1,
+      translateX: 0,
+      translateY: 0
+    };
+
     this.transformer = new Konva.Transformer({
       rotateEnabled: true,
       rotateAnchorOffset: 30,
@@ -556,6 +563,31 @@ class KonvaPanel {
     this.transformer.nodes([]);
     this.activeShape = null;
     this.layer.batchDraw();
+  }
+
+  applyViewportTransform(transform = {}) {
+    if (!this.stage) return;
+
+    const next = {
+      scaleX: typeof transform.scaleX === 'number' ? transform.scaleX : (typeof transform.scale === 'number' ? transform.scale : this.viewportTransform.scaleX),
+      scaleY: typeof transform.scaleY === 'number' ? transform.scaleY : (typeof transform.scale === 'number' ? transform.scale : this.viewportTransform.scaleY),
+      translateX: typeof transform.translateX === 'number' ? transform.translateX : (typeof transform.x === 'number' ? transform.x : this.viewportTransform.translateX),
+      translateY: typeof transform.translateY === 'number' ? transform.translateY : (typeof transform.y === 'number' ? transform.y : this.viewportTransform.translateY)
+    };
+
+    const changed =
+      next.scaleX !== this.viewportTransform.scaleX ||
+      next.scaleY !== this.viewportTransform.scaleY ||
+      next.translateX !== this.viewportTransform.translateX ||
+      next.translateY !== this.viewportTransform.translateY;
+
+    if (!changed) return;
+
+    this.viewportTransform = next;
+
+    this.stage.scale({ x: next.scaleX, y: next.scaleY });
+    this.stage.position({ x: next.translateX, y: next.translateY });
+    this.stage.batchDraw();
   }
 
   forwardPointerEvent(type, evt) {

--- a/assets/js/image-zoom-pan.js
+++ b/assets/js/image-zoom-pan.js
@@ -77,6 +77,7 @@ imageContainer.addEventListener('dblclick', (e) => {
 
 function updateImageTransform() {
   redrawAllLayers();
+  syncImageOverlay();
 }
 
 function resetImageZoom() {
@@ -84,4 +85,19 @@ function resetImageZoom() {
   imagePanX = 0;
   imagePanY = 0;
   redrawAllLayers();
+  syncImageOverlay();
 }
+
+function syncImageOverlay() {
+  if (!window.drawingRouter || !drawingRouter.konvaManager) return;
+  const panel = drawingRouter.konvaManager.getPanel('image');
+  if (!panel || typeof panel.applyViewportTransform !== 'function') return;
+  panel.applyViewportTransform({
+    scaleX: imageZoom,
+    scaleY: imageZoom,
+    translateX: imagePanX,
+    translateY: imagePanY
+  });
+}
+
+syncImageOverlay();


### PR DESCRIPTION
## Summary
- add viewport transform tracking support to the Konva panel wrapper
- sync the image overlay stage with image pan and zoom so annotations stay anchored to the imagery

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e35f38b71c8327891a330e36fd5dd8