### PR TITLE
Stabilize sun measurement arrow assignment

### DIFF
--- a/assets/js/drawing-tools.js
+++ b/assets/js/drawing-tools.js
@@ -59,6 +59,13 @@ class KonvaPanel {
     this.layer = new Konva.Layer();
     this.stage.add(this.layer);
 
+    this.viewportTransform = {
+      scaleX: 1,
+      scaleY: 1,
+      translateX: 0,
+      translateY: 0
+    };
+
     this.transformer = new Konva.Transformer({
       rotateEnabled: true,
       rotateAnchorOffset: 30,
@@ -149,11 +156,17 @@ class KonvaPanel {
     });
 
     shape.on('click tap', (evt) => {
-      if (this.router.state.tool !== 'pan') return;
+      const pendingSunAssignment = this.router && typeof this.router.hasPendingSunAssignment === 'function'
+        ? this.router.hasPendingSunAssignment()
+        : false;
+      if (!pendingSunAssignment && this.router.state.tool !== 'pan') return;
       evt.cancelBubble = true;
       this.transformer.nodes([shape]);
       this.activeShape = shape;
       this.layer.batchDraw();
+      if (this.router && typeof this.router.handleShapeSelection === 'function') {
+        this.router.handleShapeSelection(this.key, shape);
+      }
     });
 
     if (shape.getAttr('shapeType') === 'arrow') {
@@ -316,9 +329,24 @@ class KonvaPanel {
   }
 
   getPointerPosition(evt) {
-    const stage = evt.target.getStage();
+    const stage = evt && typeof evt.target?.getStage === 'function'
+      ? evt.target.getStage()
+      : this.stage;
     if (!stage) return null;
-    return stage.getPointerPosition();
+
+    const pointer = stage.getPointerPosition();
+    if (!pointer) return null;
+
+    const transform = this.viewportTransform || {};
+    const scaleX = transform.scaleX || 1;
+    const scaleY = transform.scaleY || 1;
+    const translateX = transform.translateX || 0;
+    const translateY = transform.translateY || 0;
+
+    return {
+      x: (pointer.x - translateX) / scaleX,
+      y: (pointer.y - translateY) / scaleY
+    };
   }
 
   styleAttributes() {
@@ -404,6 +432,15 @@ class KonvaPanel {
       if (pos && typeof createStickyNote === 'function') {
         createStickyNote(pos.x, pos.y, this.container);
       }
+      return;
+    }
+
+    const hasPendingSunAssignment = this.router && typeof this.router.hasPendingSunAssignment === 'function'
+      ? this.router.hasPendingSunAssignment()
+      : false;
+
+    if (hasPendingSunAssignment && evt.target !== this.stage) {
+      evt.cancelBubble = true;
       return;
     }
 
@@ -556,6 +593,51 @@ class KonvaPanel {
     this.transformer.nodes([]);
     this.activeShape = null;
     this.layer.batchDraw();
+  }
+
+  getActiveShape() {
+    if (this.activeShape && !isShapeDestroyed(this.activeShape)) {
+      return this.activeShape;
+    }
+
+    if (this.transformer && typeof this.transformer.nodes === 'function') {
+      const nodes = this.transformer.nodes();
+      if (Array.isArray(nodes)) {
+        for (const node of nodes) {
+          if (node && !isShapeDestroyed(node)) {
+            this.activeShape = node;
+            return node;
+          }
+        }
+      }
+    }
+
+    return null;
+  }
+
+  applyViewportTransform(transform = {}) {
+    if (!this.stage) return;
+
+    const next = {
+      scaleX: typeof transform.scaleX === 'number' ? transform.scaleX : (typeof transform.scale === 'number' ? transform.scale : this.viewportTransform.scaleX),
+      scaleY: typeof transform.scaleY === 'number' ? transform.scaleY : (typeof transform.scale === 'number' ? transform.scale : this.viewportTransform.scaleY),
+      translateX: typeof transform.translateX === 'number' ? transform.translateX : (typeof transform.x === 'number' ? transform.x : this.viewportTransform.translateX),
+      translateY: typeof transform.translateY === 'number' ? transform.translateY : (typeof transform.y === 'number' ? transform.y : this.viewportTransform.translateY)
+    };
+
+    const changed =
+      next.scaleX !== this.viewportTransform.scaleX ||
+      next.scaleY !== this.viewportTransform.scaleY ||
+      next.translateX !== this.viewportTransform.translateX ||
+      next.translateY !== this.viewportTransform.translateY;
+
+    if (!changed) return;
+
+    this.viewportTransform = next;
+
+    this.stage.scale({ x: next.scaleX, y: next.scaleY });
+    this.stage.position({ x: next.translateX, y: next.translateY });
+    this.stage.batchDraw();
   }
 
   forwardPointerEvent(type, evt) {
@@ -1230,6 +1312,31 @@ class KonvaManager {
     this.panels.forEach(panel => panel.clearSelection());
   }
 
+  getSelection() {
+    const orderedKeys = [];
+    if (this.activePanel) {
+      orderedKeys.push(this.activePanel);
+    }
+    this.panels.forEach((_, key) => {
+      if (!orderedKeys.includes(key)) {
+        orderedKeys.push(key);
+      }
+    });
+
+    for (const key of orderedKeys) {
+      const panel = this.panels.get(key);
+      if (!panel) continue;
+      const shape = typeof panel.getActiveShape === 'function'
+        ? panel.getActiveShape()
+        : panel.activeShape;
+      if (shape && !isShapeDestroyed(shape)) {
+        return { key, panel, shape };
+      }
+    }
+
+    return null;
+  }
+
   getPanel(key) {
     return this.panels.get(key);
   }
@@ -1262,7 +1369,8 @@ class DrawingRouter {
       ground: null,
       lastAngle: null,
       lastComputation: null,
-      warnings: []
+      warnings: [],
+      pendingRole: null
     };
   }
 
@@ -1566,41 +1674,47 @@ class DrawingRouter {
 
   setSunMeasurementRole(role) {
     if (!['height', 'shadow'].includes(role)) return;
-    const panelKey = this.konvaManager.activePanel;
-    const panel = panelKey ? this.konvaManager.getPanel(panelKey) : null;
-    if (!panel || !panel.activeShape) {
-      this.sunMeasurement.warnings = [`Select an arrow and try assigning it as the ${role}.`];
+    const selection = typeof this.konvaManager.getSelection === 'function'
+      ? this.konvaManager.getSelection()
+      : null;
+    const panelKey = selection?.key;
+    const panel = selection?.panel || (panelKey ? this.konvaManager.getPanel(panelKey) : null);
+    const shape = selection?.shape || (panel && typeof panel.getActiveShape === 'function' ? panel.getActiveShape() : panel?.activeShape);
+    let assigned = false;
+    if (panel && shape) {
+      assigned = this.tryAssignSunRole(role, shape, panelKey);
+      if (assigned) {
+        return;
+      }
+    }
+
+    this.sunMeasurement.pendingRole = role;
+
+    if (!panel || !shape) {
+      const label = role === 'height' ? 'height' : 'shadow';
+      this.sunMeasurement.warnings = [`Click an arrow to assign it as the ${label} measurement.`];
       this.updateSunMeasurementUI();
-      return;
     }
+  }
 
-    const shape = panel.activeShape;
-    if (!shape || shape.getAttr('shapeType') !== 'arrow') {
-      this.sunMeasurement.warnings = ['Only arrow measurements can be marked as height or shadow.'];
-      this.updateSunMeasurementUI();
-      return;
-    }
-
-    if (this.sunMeasurement.panelKey && this.sunMeasurement.panelKey !== panelKey) {
-      this.clearSunMeasurements({ silent: true });
-    }
-
-    this.sunMeasurement.panelKey = panelKey;
-    this.assignSunRole(role, shape, panelKey);
-    this.sunMeasurement.warnings = [];
-    this.calculateSunElevation({ auto: true });
+  hasPendingSunAssignment() {
+    return Boolean(this.sunMeasurement.pendingRole);
   }
 
   setSunGroundPlane() {
-    const panelKey = this.konvaManager.activePanel;
-    const panel = panelKey ? this.konvaManager.getPanel(panelKey) : null;
-    if (!panel || !panel.activeShape) {
+    const selection = typeof this.konvaManager.getSelection === 'function'
+      ? this.konvaManager.getSelection()
+      : null;
+    const panelKey = selection?.key;
+    const panel = selection?.panel || (panelKey ? this.konvaManager.getPanel(panelKey) : null);
+    const shape = selection?.shape || (panel && typeof panel.getActiveShape === 'function' ? panel.getActiveShape() : panel?.activeShape);
+
+    if (!panel || !shape) {
       this.sunMeasurement.warnings = ['Select a polygon that represents the ground plane before assigning it.'];
       this.updateSunMeasurementUI();
       return;
     }
 
-    const shape = panel.activeShape;
     const type = shape.getAttr('shapeType');
     if (!['polygon', 'freehand', 'line'].includes(type)) {
       this.sunMeasurement.warnings = ['Ground plane correction requires a four-corner polygon.'];
@@ -1620,9 +1734,61 @@ class DrawingRouter {
     }
 
     this.sunMeasurement.panelKey = panelKey;
+    this.sunMeasurement.pendingRole = null;
     this.assignSunRole('ground', shape, panelKey);
     this.sunMeasurement.warnings = [];
     this.calculateSunElevation({ auto: true });
+  }
+
+  handleShapeSelection(panelKey, shape) {
+    if (!shape) return;
+    if (!this.sunMeasurement.pendingRole) return;
+    const role = this.sunMeasurement.pendingRole;
+    const assigned = this.tryAssignSunRole(role, shape, panelKey);
+    if (!assigned) {
+      this.sunMeasurement.pendingRole = role;
+    }
+  }
+
+  tryAssignSunRole(role, shape, panelKey) {
+    if (!shape || typeof shape.getAttr !== 'function') return false;
+
+    if (shape.getAttr('shapeType') !== 'arrow') {
+      this.sunMeasurement.warnings = ['Only arrow measurements can be marked as height or shadow.'];
+      this.updateSunMeasurementUI();
+      return false;
+    }
+
+    const existing = this.sunMeasurement[role];
+    if (existing && existing.shape === shape && !isShapeDestroyed(shape)) {
+      if (panelKey) {
+        this.sunMeasurement.panelKey = panelKey;
+      }
+      this.sunMeasurement.pendingRole = null;
+      this.sunMeasurement.warnings = [];
+      this.calculateSunElevation({ auto: true });
+      return true;
+    }
+
+    const otherRole = role === 'height' ? 'shadow' : 'height';
+    const otherEntry = this.sunMeasurement[otherRole];
+    if (otherEntry && otherEntry.shape && !isShapeDestroyed(otherEntry.shape) && otherEntry.shape === shape) {
+      const label = role === 'height' ? 'height' : 'shadow';
+      this.sunMeasurement.warnings = [`Select a different arrow for the ${label} measurement.`];
+      this.updateSunMeasurementUI();
+      return false;
+    }
+
+    if (this.sunMeasurement.panelKey && this.sunMeasurement.panelKey !== panelKey) {
+      this.clearSunMeasurements({ silent: true });
+    }
+
+    this.sunMeasurement.panelKey = panelKey;
+    this.assignSunRole(role, shape, panelKey);
+    this.sunMeasurement.pendingRole = null;
+    this.sunMeasurement.warnings = [];
+    this.calculateSunElevation({ auto: true });
+    return true;
   }
 
   assignSunRole(role, shape, panelKey) {
@@ -1675,6 +1841,10 @@ class DrawingRouter {
     }
     this.sunMeasurement[role] = null;
 
+    if (this.sunMeasurement.pendingRole === role) {
+      this.sunMeasurement.pendingRole = null;
+    }
+
     if (!this.sunMeasurement.height && !this.sunMeasurement.shadow && !this.sunMeasurement.ground) {
       this.sunMeasurement.panelKey = null;
     }
@@ -1693,6 +1863,7 @@ class DrawingRouter {
     this.sunMeasurement.lastAngle = null;
     this.sunMeasurement.lastComputation = null;
     this.sunMeasurement.warnings = [];
+    this.sunMeasurement.pendingRole = null;
     if (!silent) {
       this.updateSunMeasurementUI();
     }

--- a/assets/js/image-zoom-pan.js
+++ b/assets/js/image-zoom-pan.js
@@ -77,6 +77,7 @@ imageContainer.addEventListener('dblclick', (e) => {
 
 function updateImageTransform() {
   redrawAllLayers();
+  syncImageOverlay();
 }
 
 function resetImageZoom() {
@@ -84,4 +85,19 @@ function resetImageZoom() {
   imagePanX = 0;
   imagePanY = 0;
   redrawAllLayers();
+  syncImageOverlay();
 }
+
+function syncImageOverlay() {
+  if (!window.drawingRouter || !drawingRouter.konvaManager) return;
+  const panel = drawingRouter.konvaManager.getPanel('image');
+  if (!panel || typeof panel.applyViewportTransform !== 'function') return;
+  panel.applyViewportTransform({
+    scaleX: imageZoom,
+    scaleY: imageZoom,
+    translateX: imagePanX,
+    translateY: imagePanY
+  });
+}
+
+syncImageOverlay();


### PR DESCRIPTION
## Summary
- allow the sun measurement buttons to queue an assignment and attach it to the next arrow that is clicked
- block assigning the same arrow to both height and shadow while surfacing clearer guidance when no arrow is selected
- hook pending sun assignments into Konva selection so clicking arrows (even while another tool is active) records the measurement instead of drawing a new shape

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e35f38b71c8327891a330e36fd5dd8