### PR TITLE
Add contextual help overlay for sun tools panel

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -282,6 +282,14 @@ body.resizing .resizer {
   align-items:flex-start;
   gap:1rem;
 }
+.sun-tools-header-actions{
+  display:flex;
+  align-items:center;
+  gap:.4rem;
+}
+.sun-tools-help{
+  box-shadow:0 6px 16px rgba(102,187,106,.3);
+}
 .sun-tools-title h4{
   margin:0;
   font-size:1rem;
@@ -352,6 +360,83 @@ body.resizing .resizer {
 .sun-tools-warnings h5{margin:0 0 .4rem;font-size:.85rem;color:#b15c00}
 .sun-tools-warnings ul{margin:0;padding-left:1.1rem;font-size:.8rem;color:#8a4a00;line-height:1.4}
 .sun-tools-warnings ul li+li{margin-top:.25rem}
+.sun-help-overlay{
+  position:fixed;
+  inset:0;
+  background:rgba(15,23,42,.55);
+  display:none;
+  align-items:center;
+  justify-content:center;
+  padding:1.5rem;
+  z-index:1100;
+}
+.sun-help-overlay.visible{display:flex}
+.sun-help-content{
+  background:#fff;
+  border-radius:16px;
+  max-width:560px;
+  width:100%;
+  padding:1.8rem;
+  box-shadow:0 18px 45px rgba(15,23,42,.25);
+  display:flex;
+  flex-direction:column;
+  gap:1.2rem;
+}
+.sun-help-header{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:.8rem;
+}
+.sun-help-header h2{
+  margin:0;
+  font-size:1.4rem;
+  color:#0f172a;
+}
+.sun-help-close{
+  background:none;
+  border:none;
+  font-size:1.8rem;
+  line-height:1;
+  cursor:pointer;
+  color:#475569;
+  padding:.15rem .4rem;
+  border-radius:8px;
+  transition:background .2s,color .2s;
+}
+.sun-help-close:hover{background:rgba(148,163,184,.2);color:#0f172a}
+.sun-help-body{
+  display:flex;
+  flex-direction:column;
+  gap:1rem;
+  color:#334155;
+  font-size:.95rem;
+  line-height:1.6;
+}
+.sun-help-body ol{margin:0;padding-left:1.2rem;display:flex;flex-direction:column;gap:.5rem}
+.sun-help-body li strong{color:#0f172a}
+.sun-help-examples{
+  background:#f8fafc;
+  border:1px solid #e2e8f0;
+  border-radius:12px;
+  padding:1rem 1.1rem;
+  display:flex;
+  flex-direction:column;
+  gap:.6rem;
+}
+.sun-help-examples h3{
+  margin:0;
+  font-size:1.05rem;
+  color:#1e293b;
+}
+.sun-help-examples ul{margin:0;padding-left:1.1rem;display:flex;flex-direction:column;gap:.4rem;font-size:.9rem;color:#475569}
+.sun-help-examples li strong{color:#0f172a}
+.sun-help-tip{
+  margin:0;
+  font-size:.9rem;
+  color:#2563eb;
+  font-weight:600;
+}
 
 .tool-btn{
   padding:.5rem .8rem;border:2px solid #ddd;

--- a/assets/js/drawing-tools.js
+++ b/assets/js/drawing-tools.js
@@ -2497,6 +2497,24 @@ function calculateSunElevation() {
   drawingRouter.calculateSunElevation({ auto: false });
 }
 
+function showSunToolsHelp() {
+  const overlay = document.getElementById('sunHelpOverlay');
+  if (!overlay) return;
+  overlay.classList.add('visible');
+  overlay.setAttribute('aria-hidden', 'false');
+  const closeButton = overlay.querySelector('.sun-help-close');
+  if (closeButton && typeof closeButton.focus === 'function') {
+    closeButton.focus();
+  }
+}
+
+function hideSunToolsHelp() {
+  const overlay = document.getElementById('sunHelpOverlay');
+  if (!overlay) return;
+  overlay.classList.remove('visible');
+  overlay.setAttribute('aria-hidden', 'true');
+}
+
 function undoLast() {
   if (Array.isArray(stickyNotes) && stickyNotes.length > 0) {
     const lastNote = stickyNotes[stickyNotes.length - 1];
@@ -2569,3 +2587,23 @@ window.setSunMeasurementRole = setSunMeasurementRole;
 window.setSunGroundPlane = setSunGroundPlane;
 window.clearSunMeasurements = clearSunMeasurements;
 window.calculateSunElevation = calculateSunElevation;
+window.showSunToolsHelp = showSunToolsHelp;
+window.hideSunToolsHelp = hideSunToolsHelp;
+
+const sunHelpOverlay = document.getElementById('sunHelpOverlay');
+if (sunHelpOverlay) {
+  sunHelpOverlay.addEventListener('click', (event) => {
+    if (event.target === sunHelpOverlay) {
+      hideSunToolsHelp();
+    }
+  });
+}
+
+document.addEventListener('keydown', (event) => {
+  if (event.key === 'Escape') {
+    const overlay = document.getElementById('sunHelpOverlay');
+    if (overlay && overlay.classList.contains('visible')) {
+      hideSunToolsHelp();
+    }
+  }
+});

--- a/geolocator.html
+++ b/geolocator.html
@@ -499,7 +499,10 @@
               <h4>Sun Elevation (Advanced)</h4>
               <p>Mark height and shadow measurements to estimate the sun elevation. Assign a ground plane if you need perspective correction.</p>
             </div>
-            <button class="sun-tools-close" type="button" onclick="toggleSunToolsPanel(false)" aria-label="Close sun tools">×</button>
+            <div class="sun-tools-header-actions">
+              <button class="help-btn sun-tools-help" type="button" onclick="showSunToolsHelp()" title="How to use the sun tools" aria-haspopup="dialog" aria-controls="sunHelpOverlay">?</button>
+              <button class="sun-tools-close" type="button" onclick="toggleSunToolsPanel(false)" aria-label="Close sun tools">×</button>
+            </div>
           </div>
           <div class="sun-tools-body">
             <div class="sun-tools-assignments">
@@ -529,6 +532,35 @@
               <ul id="sunWarnings"></ul>
             </div>
           </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Sun Tools Help Overlay -->
+  <div class="sun-help-overlay" id="sunHelpOverlay" aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="sunHelpTitle">
+    <div class="sun-help-content" role="document">
+      <div class="sun-help-header">
+        <h2 id="sunHelpTitle">☀️ Sun Tools Guide</h2>
+        <button class="sun-help-close" type="button" onclick="hideSunToolsHelp()" aria-label="Close sun tools guide">×</button>
+      </div>
+      <div class="sun-help-body">
+        <p>The sun tools convert the relationship between an object's height and its shadow into a solar elevation estimate. Follow these steps to collect accurate measurements:</p>
+        <ol>
+          <li><strong>Mark the height arrow.</strong> Select <em>Mark Height Arrow</em> and draw a line from the base of the object to the top. Use straight edges like flagpoles, trees, or building corners.</li>
+          <li><strong>Mark the shadow arrow.</strong> Choose <em>Mark Shadow Arrow</em> and trace the object's shadow from the base toward the sun. Align the arrow with clear shadow edges for best results.</li>
+          <li><strong>Assign a ground plane (optional).</strong> If the photo is tilted, pick <em>Assign Ground Plane</em> and outline a flat surface to correct the perspective before calculating the angle.</li>
+          <li><strong>Add a real-world height (optional).</strong> Enter a known height to turn the relative measurement into a real-world distance check.</li>
+          <li><strong>Compute the angle.</strong> Click <em>Compute Angle</em> to display the sun's elevation and review any notes or warnings.</li>
+        </ol>
+        <div class="sun-help-examples">
+          <h3>Example Scenarios</h3>
+          <ul>
+            <li><strong>Street scene:</strong> Use a streetlight pole for the height arrow and its shadow on the pavement. If the camera is tilted, assign the road surface as the ground plane.</li>
+            <li><strong>Building facade:</strong> Trace the height along a window edge and the shadow cast on the sidewalk. Enter the building floor height if known to validate the measurement.</li>
+            <li><strong>Landscape photo:</strong> Mark a tree trunk and its shadow. Even without a known height, the computed angle lets you compare against solar ephemeris data for the capture time.</li>
+          </ul>
+          <p class="sun-help-tip">Tip: Keep arrows tight to the object's edges. Short, precise arrows produce more reliable sun angles.</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add a contextual help button to the sun tools header that opens a detailed guide overlay
- style the new sun tools help overlay and button for visual consistency with existing UI components
- implement JavaScript helpers to toggle the overlay, focus the close control, and support click-away and Escape closing

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e4b9de055083278bdd2ce6cd8d6506