### PR TITLE
Activate panel when assigning sun measurement

### DIFF
--- a/assets/js/drawing-tools.js
+++ b/assets/js/drawing-tools.js
@@ -1692,6 +1692,9 @@ class DrawingRouter {
       ? this.konvaManager.getSelection()
       : null;
     const panelKey = selection?.key;
+    if (panelKey && typeof this.setActivePanel === 'function') {
+      this.setActivePanel(panelKey);
+    }
     const panel = selection?.panel || (panelKey ? this.konvaManager.getPanel(panelKey) : null);
     const shape = selection?.shape || (panel && typeof panel.getActiveShape === 'function' ? panel.getActiveShape() : panel?.activeShape);
     const existingEntry = this.sunMeasurement[role];


### PR DESCRIPTION
## Summary
- activate the panel associated with the current selection when starting a sun measurement assignment so the overlay receives pointer events

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e4fb774fb483278b968d3bbcbeaff8