### PR TITLE
Prevent conflicting sun measurement auto assignment

### DIFF
--- a/assets/js/drawing-tools.js
+++ b/assets/js/drawing-tools.js
@@ -1692,16 +1692,23 @@ class DrawingRouter {
       ? this.konvaManager.getSelection()
       : null;
     const panelKey = selection?.key;
+    if (panelKey && typeof this.setActivePanel === 'function') {
+      this.setActivePanel(panelKey);
+    }
     const panel = selection?.panel || (panelKey ? this.konvaManager.getPanel(panelKey) : null);
     const shape = selection?.shape || (panel && typeof panel.getActiveShape === 'function' ? panel.getActiveShape() : panel?.activeShape);
     const existingEntry = this.sunMeasurement[role];
     const existingShape = existingEntry?.shape;
     const selectingExisting = panel && shape && existingShape && !isShapeDestroyed(existingShape) && shapesMatch(existingShape, shape);
+    const shapeAssignment = shape && typeof shape.getAttr === 'function' ? shape.getAttr('sunAssignmentRole') : null;
+    const eligibleForImmediateAssignment = panel && shape && (!shapeAssignment || shapeAssignment === role);
     let assigned = false;
+    let messageSet = false;
+
+    this.sunMeasurement.pendingRole = role;
 
     if (selectingExisting) {
       const label = role === 'height' ? 'height' : 'shadow';
-      this.sunMeasurement.pendingRole = role;
       this.sunMeasurement.warnings = [`Select a different arrow to reassign the ${label} measurement.`];
       if (this.konvaManager && typeof this.konvaManager.clearSelections === 'function') {
         this.konvaManager.clearSelections();
@@ -1710,10 +1717,13 @@ class DrawingRouter {
       return;
     }
 
-    if (panel && shape) {
+    if (eligibleForImmediateAssignment) {
       assigned = this.tryAssignSunRole(role, shape, panelKey);
       if (assigned) {
         return;
+      }
+      if (Array.isArray(this.sunMeasurement.warnings) && this.sunMeasurement.warnings.length > 0) {
+        messageSet = true;
       }
 
       const otherRole = role === 'height' ? 'shadow' : 'height';
@@ -1721,11 +1731,14 @@ class DrawingRouter {
       if (shapesMatch(otherShape, shape) && this.konvaManager && typeof this.konvaManager.clearSelections === 'function') {
         this.konvaManager.clearSelections();
       }
+    } else if (panel && shape) {
+      const label = role === 'height' ? 'height' : 'shadow';
+      this.sunMeasurement.warnings = [`Click an arrow to assign it as the ${label} measurement.`];
+      this.updateSunMeasurementUI();
+      messageSet = true;
     }
 
-    this.sunMeasurement.pendingRole = role;
-
-    if (!panel || !shape) {
+    if ((!panel || !shape) && !messageSet) {
       const label = role === 'height' ? 'height' : 'shadow';
       this.sunMeasurement.warnings = [`Click an arrow to assign it as the ${label} measurement.`];
       this.updateSunMeasurementUI();


### PR DESCRIPTION
## Summary
- avoid immediately reusing a shape already assigned to the opposite sun measurement when starting a new assignment
- keep the user in assignment mode with clear guidance to click a different arrow if the current selection cannot be reused

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e4fb774fb483278b968d3bbcbeaff8