### PR TITLE
Improve peakfinder event forwarding through drawing overlay

### DIFF
--- a/assets/js/line-of-sight.js
+++ b/assets/js/line-of-sight.js
@@ -321,11 +321,15 @@ async function initializePeakFinder() {
     document.getElementById('mapCanvas').style.display = 'none';
     document.getElementById('view3DContainer').classList.remove('active');
     document.getElementById('peakFinderContainer').classList.add('active');
-    
+
     document.getElementById('viewToggleBtn').style.display = 'flex';
     document.getElementById('viewInfoBar').classList.add('visible');
     document.getElementById('viewToggleIcon').textContent = '🗺️';
     document.getElementById('viewToggleText').textContent = 'Back to 2D Map';
+  }
+
+  if (typeof syncDrawingPanel === 'function') {
+    syncDrawingPanel();
   }
   
   if (peakFinderPanel) {
@@ -381,6 +385,10 @@ function hidePeakFinder() {
   document.getElementById('peakFinderContainer').classList.remove('active');
   if (currentView === 'peakfinder') {
     currentView = '2d';
+  }
+
+  if (typeof syncDrawingPanel === 'function') {
+    syncDrawingPanel();
   }
 }
 

--- a/assets/js/places-mode.js
+++ b/assets/js/places-mode.js
@@ -224,6 +224,9 @@ let drawDetachedView = '2d';
 
 function syncDrawingPanel() {
   if (typeof drawingRouter === 'undefined') return;
+  if (drawingRouter && drawingRouter.konvaManager && typeof drawingRouter.konvaManager.cancelForwarding === 'function') {
+    drawingRouter.konvaManager.cancelForwarding();
+  }
   if (mapMode !== 'draw') {
     drawingRouter.setActivePanel(null);
     return;


### PR DESCRIPTION
## Summary
- forward click, double-click, and wheel gestures through the Konva overlay while panning so the underlying viewers stay interactive
- cancel any in-flight pointer forwarding when the active view changes and resync the drawing panel when PeakFinder is shown or hidden

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e51420f4788327bccf1c3f53624643